### PR TITLE
Moved querying of environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ var loaderSchema = require('./schema/loader-schema');
 var pluginSchema = require('./schema/plugin-schema.json');
 
 var NS = fs.realpathSync(__dirname);
-var DEV = process.env.NODE_ENV === 'development';
 var nextId = 0;
 
 function ExtractTextPluginCompilation() {
@@ -108,7 +107,7 @@ function ExtractTextPlugin(options) {
 	} else {
 		schemaTester(pluginSchema, options);
 	}
-	this.filename = options.filename || (DEV ? '[name].css' : '[name].[contenthash].css');
+	this.filename = options.filename || (process.env.NODE_ENV === 'development' ? '[name].css' : '[name].[contenthash].css');
 	this.id = options.id != null ? options.id : ++nextId;
 	this.options = {};
 	mergeOptions(this.options, options);
@@ -292,7 +291,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 
 		// HMR: inject file name into corresponding javascript modules in order to trigger
 		// appropriate hot module reloading of CSS
-		if (DEV) {
+		if (process.env.NODE_ENV === 'development') {
 			compilation.plugin("before-chunk-assets", function() {
 				extractedChunks.forEach(function(extractedChunk) {
 					extractedChunk.modules.forEach(function(module) {

--- a/loader.js
+++ b/loader.js
@@ -13,7 +13,6 @@ var SingleEntryPlugin = require("webpack/lib/SingleEntryPlugin");
 var LimitChunkCountPlugin = require("webpack/lib/optimize/LimitChunkCountPlugin");
 
 var NS = fs.realpathSync(__dirname);
-var DEV = process.env.NODE_ENV === 'development'
 
 module.exports = function(source) {
 	return source;
@@ -133,7 +132,7 @@ module.exports.pitch = function(request) {
 					//
 					// All we need is a date that changes during dev, to trigger a reload since
 					// hashes generated based on the file contents are what trigger HMR.
-					if (DEV) {
+					if (process.env.NODE_ENV === 'development') {
 						resultSource += `
 if (module.hot) {
 	module.hot.accept();


### PR DESCRIPTION
This fixes issues when environment variable is not configured before importing the module... which can be true for I figure a lot of Webpack configuration generators/factories like [edge-builder](https://github.com/sebastian-software/edge-builder). It imports dependencies via ESM import and executes the `main` function afterwards to parse command line arguments, etc.