### PR TITLE
Fix error message to refer to correct plugin

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -35,8 +35,8 @@ module.exports.pitch = function(request) {
 	// We already in child compiler, return empty bundle
 	if(this[NS] === undefined) {
 		throw new Error(
-			'"extract-text-webpack-plugin" loader is used without the corresponding plugin, ' +
-			'refer to https://github.com/webpack/extract-text-webpack-plugin for the usage example'
+			'"extract-css-chunks-webpack-plugin" loader is used without the corresponding plugin, ' +
+			'refer to https://github.com/faceyspacey/extract-css-chunks-webpack-plugin for the usage example'
 		);
 	} else if(this[NS] === false) {
 		return "";


### PR DESCRIPTION
My webpack setup uses both `extract-text-webpack-plugin` and this package, in different situations.  So I was scratching my head for a while when I got this error message that referenced extract-text but was really coming from this one.

Anyways, there are a few other places that have `extract-text-webpack-plugin` in the loader, but I left them alone because I don't know how they're used, and maybe they're necessary.  But I think it's safe to fix the error message.