### PR TITLE
Update of error reporting by the isChunk(..) function

### DIFF
--- a/index.js
+++ b/index.js
@@ -356,9 +356,9 @@ function getPath(compilation, source, chunk) {
 
 function isChunk(chunk, error) {
 	if (!(chunk instanceof Chunk)) {
-    var e = chunk && chunk.entryModule && chunk.entryModule.error;
+    var e = (chunk && chunk.entryModule && chunk.entryModule.error) || error;
     if (e instanceof Error) throw e;
-		throw new Error(typeof e === 'string' ? e : 'chunk is not an instance of Chunk');
+    throw new Error(typeof e === 'string' ? e : 'chunk is not an instance of Chunk');
 	}
 
 	return true;

--- a/index.js
+++ b/index.js
@@ -356,7 +356,9 @@ function getPath(compilation, source, chunk) {
 
 function isChunk(chunk, error) {
 	if (!(chunk instanceof Chunk)) {
-		throw new Error(typeof error === 'string' ? error : 'chunk is not an instance of Chunk');
+    var e = chunk && chunk.entryModule && chunk.entryModule.error;
+    if (e instanceof Error) throw e;
+		throw new Error(typeof e === 'string' ? e : 'chunk is not an instance of Chunk');
 	}
 
 	return true;


### PR DESCRIPTION
In case the chunk build failed, the chunk object passed into isChunk(..)
contains the actual error message, which is thrown by the plugin. Before
this change it was throwing a non-informative "chunk is not an instance
of Chunk" message.
