### PR TITLE
Force allChunks to true - fix non-deterministic build

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,9 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 					content: content,
 					options: opt || {}
 				};
-				return options.allChunks || module[NS + "/extract"]; // eslint-disable-line no-path-concat
+
+				// SETTING THIS TO TRUE INSURES A DETERMINISTIC BUILD:
+				return true; //options.allChunks || module[NS + "/extract"];
 			};
 		});
 		var filename = this.filename;


### PR DESCRIPTION
As you consider that `allChunks` is always `true` for `shouldExtract`, I think we should force it everywhere. It corrects a non-deterministic build for us: sometimes `css-base.js` file  from `css-loader` lib was in the bundle, sometimes it wasn't the case and hashing wasn't consistent 😞 