### PR TITLE
Fix for 'chunk is not an instance of Chunk'

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,7 +355,14 @@ function getPath(compilation, source, chunk) {
 }
 
 function isChunk(chunk, error) {
-	if (!(chunk instanceof Chunk)) {
+	if (
+		!chunk ||
+		(
+			!chunk.modulesIterable &&
+			!chunk.forEachModule &&
+			!chunk.modules
+		)
+	) {
 		throw new Error(typeof error === 'string' ? error : 'chunk is not an instance of Chunk');
 	}
 


### PR DESCRIPTION
See https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/issues/66