### PR TITLE
fix(.eslintrc,hotModuleReplacement.js): Update linting rules, no arrows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
         'no-underscore-dangle': 0,
         'no-restricted-syntax': 0,
         'prefer-arrow-callback': 0,
-        'prefer-destructuring': 0
+        'prefer-destructuring': 0,
+        'prefer-template': 0
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
         'func-names': 0,
         'no-underscore-dangle': 0,
         'no-restricted-syntax': 0,
-        'prefer-arrow-callback': 0
+        'prefer-arrow-callback': 0,
+        'prefer-destructuring': 0
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,21 +1,22 @@
 module.exports = {
-	parser: 'babel-eslint',
-	parserOptions: {
-		ecmaFeatures: {
-			generators: true,
-			experimentalObjectRestSpread: true
-		},
-		sourceType: 'module',
-		allowImportExportEverywhere: false
-	},
-	extends: ['airbnb'],
-	env: {
-		'browser': true,
-	},
-	rules: {
-		'no-param-reassign': 0,
-		'func-names': 0,
-		'no-underscore-dangle': 0,
-		'no-restricted-syntax': 0,
-	}
+    parser: 'babel-eslint',
+    parserOptions: {
+        ecmaFeatures: {
+            generators: true,
+            experimentalObjectRestSpread: true
+        },
+        sourceType: 'module',
+        allowImportExportEverywhere: false
+    },
+    extends: ['airbnb'],
+    env: {
+        'browser': true,
+    },
+    rules: {
+        'no-param-reassign': 0,
+        'func-names': 0,
+        'no-underscore-dangle': 0,
+        'no-restricted-syntax': 0,
+        'prefer-arrow-callback': 0
+    }
 };

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ NOTE: We have aligned out loader implementation to be the same as `mini-css-extr
 
 **If you already use `mini-css-extract-plugin`, then you can just change the `require` statement - it's that easy**
 
-
-**DONT USE THIS INSTALL CMD IF YOU ARE BETA TESTING:**
 ```
 yarn add --dev extract-css-chunks-webpack-plugin
 ```

--- a/src/hotModuleReplacement.js
+++ b/src/hotModuleReplacement.js
@@ -31,7 +31,7 @@ const getCurrentScriptUrl = function (moduleId) {
     if (!filename) {
       return [src.replace('.js', '.css')];
     }
-    return fileMap.split(',').map((mapRule) => {
+    return fileMap.split(',').map(function (mapRule) {
       const reg = new RegExp(`${filename}\\.js$`, 'g');
       return normalizeUrl(
         src.replace(reg, `${mapRule.replace(/{fileName}/g, filename)}.css`),
@@ -56,11 +56,11 @@ function updateCss(el, url) {
   const newEl = el.cloneNode();
 
   newEl.isLoaded = false;
-  newEl.addEventListener('load', () => {
+  newEl.addEventListener('load', function () {
     newEl.isLoaded = true;
     el.remove();
   });
-  newEl.addEventListener('error', () => {
+  newEl.addEventListener('error', function () {
     newEl.isLoaded = true;
     el.remove();
   });
@@ -72,7 +72,7 @@ function updateCss(el, url) {
 function getReloadUrl(href, src) {
   href = normalizeUrl(href, { stripWWW: false });
   let ret;
-  src.some((url) => { // eslint-disable-line array-callback-return
+  src.some(function (url) { // eslint-disable-line array-callback-return
     if (href.indexOf(src) > -1) {
       ret = url;
     }
@@ -84,7 +84,7 @@ function reloadStyle(src) { // eslint-disable-line no-unused-vars
   const elements = document.querySelectorAll('link');
   let loaded = false;
 
-  forEach.call(elements, (el) => {
+  forEach.call(elements, function (el) {
     if (el.visited === true) return;
 
     const url = getReloadUrl(el.href, src);
@@ -99,7 +99,7 @@ function reloadStyle(src) { // eslint-disable-line no-unused-vars
 
 function reloadAll() {
   const elements = document.querySelectorAll('link');
-  forEach.call(elements, (el) => {
+  forEach.call(elements, function (el) {
     if (el.visited === true) return;
     updateCss(el);
   });

--- a/src/hotModuleReplacement.js
+++ b/src/hotModuleReplacement.js
@@ -4,7 +4,7 @@ const srcByModuleId = Object.create(null);
 const debounce = require('lodash/debounce');
 
 const noDocument = typeof document === 'undefined';
-const { forEach } = Array.prototype;
+const forEach = Array.prototype.forEach;
 
 const noop = function () {};
 
@@ -13,13 +13,13 @@ const getCurrentScriptUrl = function (moduleId) {
 
   if (!src) {
     if (document.currentScript) {
-      src = document.currentScript.src; // eslint-disable-line prefer-destructuring
+      src = document.currentScript.src;
     } else {
       const scripts = document.getElementsByTagName('script');
       const lastScriptTag = scripts[scripts.length - 1];
 
       if (lastScriptTag) {
-        src = lastScriptTag.src; // eslint-disable-line prefer-destructuring
+        src = lastScriptTag.src;
       }
     }
     srcByModuleId[moduleId] = src;
@@ -43,7 +43,7 @@ const getCurrentScriptUrl = function (moduleId) {
 
 function updateCss(el, url) {
   if (!url) {
-    [url] = el.href.split('?');
+    url = el.href.split('?')[0];
   }
   if (el.isLoaded === false) {
     // We seem to be about to replace a css link that hasn't loaded yet.

--- a/src/hotModuleReplacement.js
+++ b/src/hotModuleReplacement.js
@@ -32,9 +32,9 @@ const getCurrentScriptUrl = function (moduleId) {
       return [src.replace('.js', '.css')];
     }
     return fileMap.split(',').map(function (mapRule) {
-      const reg = new RegExp(`${filename}\\.js$`, 'g');
+      const reg = new RegExp(filename + '\\.js$', 'g');
       return normalizeUrl(
-        src.replace(reg, `${mapRule.replace(/{fileName}/g, filename)}.css`),
+        src.replace(reg, mapRule.replace(/{fileName}/g, filename) + '.css'),
         { stripWWW: false },
       );
     });
@@ -65,7 +65,7 @@ function updateCss(el, url) {
     el.remove();
   });
 
-  newEl.href = `${url}?${Date.now()}`;
+  newEl.href = url + '?' + Date.now();
   el.parentNode.appendChild(newEl);
 }
 


### PR DESCRIPTION
Arrow functions break IE11 (whats new), updated eslint so it wont auto fix it

fix #83
