### PR TITLE
Fix el.remove()

### DIFF
--- a/src/hotModuleReplacement.js
+++ b/src/hotModuleReplacement.js
@@ -58,11 +58,11 @@ function updateCss(el, url) {
   newEl.isLoaded = false;
   newEl.addEventListener('load', function () {
     newEl.isLoaded = true;
-    el.remove();
+    el.parentNode.removeChild(el);
   });
   newEl.addEventListener('error', function () {
     newEl.isLoaded = true;
-    el.remove();
+    el.parentNode.removeChild(el);
   });
 
   newEl.href = url + '?' + Date.now();


### PR DESCRIPTION
[Element.remove()](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove) is not supported in IE11.