### PR TITLE
fix: Fixed HMR issue when oneOf is used

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # extract-css-chunks-webpack-plugin maintainers
-*   @faceyspacey @ScriptedAlchemy
+*  @ScriptedAlchemy

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-placeholder",
   "author": "James Gillmore <james@faceyspacey.com>",
   "contributors": [
-    "Zack Jackson <zackary.l.jackson@gmail.com> (https://github.com/ScriptedAlchemy)"
+    "Zack Jackson <zack@ScriptedAlchemy.com> (https://github.com/ScriptedAlchemy)"
   ],
   "description": "Extract CSS from chunks into stylesheets + HMR. Supports Webpack 4",
   "engines": {


### PR DESCRIPTION
When using oneOf, HRM is never activated. This patch improved the lookup system used for determining
if CSS can and should be reloaded. There have been some other tweaks for css modules and HMR

fix #98,#80