### PR TITLE
FIX-NESTED-LOADER-HMR - Fix n-depth nested loader usage where HMR fails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -397,24 +397,34 @@ class ExtractCssChunks {
     });
   }
 
+  traverseDepthFirst = (root, visit) => {
+    let nodesToVisit = [root];
+
+    while (nodesToVisit.length > 0) {
+      const currentNode = nodesToVisit.shift();
+
+      if (currentNode !== null && typeof currentNode === 'object') {
+        const children = Object.values(currentNode);
+        nodesToVisit = [...children, ...nodesToVisit];
+      }
+
+      visit(currentNode);
+    }
+  };
+
   updateWebpackConfig(rulez) {
-    let isExtract = null;
     return rulez.reduce((rules, rule) => {
-      if (rule.oneOf) {
-        rule.oneOf = this.updateWebpackConfig(rule.oneOf);
-      }
-
-      if (rule.use && Array.isArray(rule.use)) {
-        isExtract = rule.use.some((l) => {
-          const needle = l.loader || l;
-          return needle.includes(pluginName);
-        });
-
-        if (isExtract) {
-          rule.use.unshift(hotLoader);
+      this.traverseDepthFirst(rule, (node) => {
+        if (node !== null && node.use && Array.isArray(node.use)) {
+          const isMiniCss = node.use.some((l) => {
+            const needle = l.loader || l;
+            return needle.includes(pluginName);
+          });
+          if (isMiniCss) {
+            node.use.unshift(hotLoader);
+          }
         }
-      }
-
+      });
       rules.push(rule);
 
       return rules;


### PR DESCRIPTION
Fixing HMR for loader configuration where the config might consist of n-depth nesting of oneOf / use.

Uses depth first traversal to visit all the nodes and applies the hotloader wherever is necessary. Queue is used for traversal to limit the stack depth..