### PR TITLE
fix(index.js): Improved HMR detection multi instance collisions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-css-chunks-webpack-plugin",
-  "version": "0.0.0-placeholder",
+  "version": "3.1.2-beta.3",
   "author": "James Gillmore <james@faceyspacey.com>",
   "contributors": [
     "Zack Jackson <zack@ScriptedAlchemy.com> (https://github.com/ScriptedAlchemy)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-css-chunks-webpack-plugin",
-  "version": "3.1.2-beta.6",
+  "version": "3.1.2-beta.7",
   "author": "James Gillmore <james@faceyspacey.com>",
   "contributors": [
     "Zack Jackson <zack@ScriptedAlchemy.com> (https://github.com/ScriptedAlchemy)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-css-chunks-webpack-plugin",
-  "version": "3.1.2-beta.3",
+  "version": "3.1.2-beta.4",
   "author": "James Gillmore <james@faceyspacey.com>",
   "contributors": [
     "Zack Jackson <zack@ScriptedAlchemy.com> (https://github.com/ScriptedAlchemy)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-css-chunks-webpack-plugin",
-  "version": "0.0.0-placeholder",
+  "version": "3.1.2-beta.6",
   "author": "James Gillmore <james@faceyspacey.com>",
   "contributors": [
     "Zack Jackson <zack@ScriptedAlchemy.com> (https://github.com/ScriptedAlchemy)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-css-chunks-webpack-plugin",
-  "version": "3.1.2-beta.4",
+  "version": "0.0.0-placeholder",
   "author": "James Gillmore <james@faceyspacey.com>",
   "contributors": [
     "Zack Jackson <zack@ScriptedAlchemy.com> (https://github.com/ScriptedAlchemy)"
@@ -24,7 +24,9 @@
     "hmr",
     "universal",
     "webpack",
-    "webpack 4"
+    "webpack 4",
+    "css-hot-loader",
+    "extract-css-chunks-webpack-plugin"
   ],
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "extract-css-chunks-webpack-plugin",
-  "version": "3.1.2-beta.7",
+  "version": "3.1.2",
   "author": "James Gillmore <james@faceyspacey.com>",
   "contributors": [
     "Zack Jackson <zack@ScriptedAlchemy.com> (https://github.com/ScriptedAlchemy)"
   ],
-  "description": "Extract CSS from chunks into stylesheets + HMR. Supports Webpack 4",
+  "description": "Extract CSS from chunks into stylesheets + HMR. Supports Webpack 4 + SSR",
   "engines": {
     "node": ">= 6.9.0 <7.0.0 || >= 8.9.0"
   },

--- a/src/hotLoader.js
+++ b/src/hotLoader.js
@@ -3,6 +3,7 @@ const loaderUtils = require('loader-utils');
 
 const defaultOptions = {
   fileMap: '{fileName}',
+  cssModules: true,
 };
 
 module.exports = function (content) {
@@ -13,7 +14,7 @@ module.exports = function (content) {
         loaderUtils.getOptions(this),
     );
 
-  const accept = options.cssModule ? '' : 'module.hot.accept(undefined, cssReload);';
+  const accept = options.cssModules ? '' : 'module.hot.accept(undefined, cssReload);';
   return content + `
     if(module.hot) {
       // ${Date.now()}

--- a/src/hotModuleReplacement.js
+++ b/src/hotModuleReplacement.js
@@ -53,13 +53,15 @@ function updateCss(el, url) {
   const newEl = el.cloneNode();
 
   newEl.isLoaded = false;
+
   newEl.addEventListener('load', function () {
     newEl.isLoaded = true;
-    el.remove();
+    el.parentNode.removeChild(el);
   });
+
   newEl.addEventListener('error', function () {
     newEl.isLoaded = true;
-    el.remove();
+    el.parentNode.removeChild(el);
   });
 
   newEl.href = url + '?' + Date.now();

--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,7 @@ class ExtractCssChunks {
         compiler.options.module.rules = this.updateWebpackConfig(compiler.options.module.rules);
       }
     } catch (e) {
-      console.error('Something went wrong: contact the author', JSON.stringify(e)); // eslint-disable-line no-console
+      throw new Error(`Something went wrong: contact the author: ${JSON.stringify(e)}`);
     }
 
     compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
@@ -408,7 +408,7 @@ class ExtractCssChunks {
   updateWebpackConfig(rulez) {
     return rulez.reduce((rules, rule) => {
       this.traverseDepthFirst(rule, (node) => {
-        if (node !== null && node.use && Array.isArray(node.use)) {
+        if (node && node.use && Array.isArray(node.use)) {
           const isMiniCss = node.use.some((l) => {
             const needle = l.loader || l;
             return needle.includes(pluginName);

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,8 @@ class CssDependency extends webpack.Dependency {
 }
 
 class CssDependencyTemplate {
-  apply() {}
+  apply() {
+  }
 }
 
 class CssModule extends webpack.Module {
@@ -83,7 +84,8 @@ class CssModule extends webpack.Module {
   }
 
   nameForCondition() {
-    const resource = this._identifier.split('!').pop();
+    const resource = this._identifier.split('!')
+            .pop();
     const idx = resource.indexOf('?');
     if (idx >= 0) return resource.substring(0, idx);
     return resource;
@@ -187,9 +189,10 @@ class ExtractCssChunks {
       compilation.mainTemplate.hooks.renderManifest.tap(
                 pluginName,
                 (result, { chunk }) => {
-                  const renderedModules = Array.from(chunk.modulesIterable).filter(
-                        module => module.type === NS,
-                    );
+                  const renderedModules = Array.from(chunk.modulesIterable)
+                        .filter(
+                            module => module.type === NS,
+                        );
                   if (renderedModules.length > 0) {
                     result.push({
                       render: () =>
@@ -397,24 +400,34 @@ class ExtractCssChunks {
     });
   }
 
+  traverseDepthFirst(root, visit) {
+    let nodesToVisit = [root];
+
+    while (nodesToVisit.length > 0) {
+      const currentNode = nodesToVisit.shift();
+
+      if (currentNode !== null && typeof currentNode === 'object') {
+        const children = Object.values(currentNode);
+        nodesToVisit = [...children, ...nodesToVisit];
+      }
+
+      visit(currentNode);
+    }
+  }
+
   updateWebpackConfig(rulez) {
-    let isExtract = null;
     return rulez.reduce((rules, rule) => {
-      if (rule.oneOf) {
-        rule.oneOf = this.updateWebpackConfig(rule.oneOf);
-      }
-
-      if (rule.use && Array.isArray(rule.use)) {
-        isExtract = rule.use.some((l) => {
-          const needle = l.loader || l;
-          return needle.includes(pluginName);
-        });
-
-        if (isExtract) {
-          rule.use.unshift(hotLoader);
+      this.traverseDepthFirst(rule, (node) => {
+        if (node !== null && node.use && Array.isArray(node.use)) {
+          const isMiniCss = node.use.some((l) => {
+            const needle = l.loader || l;
+            return needle.includes(pluginName);
+          });
+          if (isMiniCss) {
+            node.use.unshift(hotLoader);
+          }
         }
-      }
-
+      });
       rules.push(rule);
 
       return rules;

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ class CssModuleFactory {
 class ExtractCssChunks {
   constructor(options) {
     this.options = Object.assign({ filename: '[name].css' }, options);
-    const { cssModules, reloadAll } = options;
+    const { cssModules, reloadAll } = this.options;
 
     if (!this.options.chunkFilename) {
       const { filename } = this.options;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const hotLoader = path.resolve(__dirname, './hotLoader.js');
 const { ConcatSource, SourceMapSource, OriginalSource } = sources;
 const { Template, util: { createHash } } = webpack;
 
-const NS = path.dirname(fs.realpathSync(__filename));
+const NS = '_extractCssChunks';
 
 const pluginName = 'extract-css-chunks-webpack-plugin';
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -53,7 +53,7 @@ export function pitch(request) {
   new SingleEntryPlugin(
     this.context,
     `!!${request}`,
-    pluginName
+    pluginName,
   ).apply(childCompiler,
   );
   new LimitChunkCountPlugin({ maxChunks: 1 }).apply(childCompiler);
@@ -91,7 +91,7 @@ export function pitch(request) {
           delete compilation.assets[file]; // eslint-disable-line no-param-reassign
         });
       });
-    }
+    },
   );
 
   const callback = this.async();
@@ -128,7 +128,7 @@ export function pitch(request) {
           };
         });
       }
-      this[NS](text);
+      this._extractCssChunks(text);
     } catch (e) {
       return callback(e);
     }


### PR DESCRIPTION
- Merging a PR which improved upon my initial code which allowed the plugin to automatically hot
reload. With the help of React Static, we are able to fix a bug that appeared when building out
build toolchains. This bug causes the pugin to have two seperate context references within webpack
and ends up passing incorrect references to the wrong instance. Deceptivally simple solution was
naming the context key myself.

-fix(nested-loaders-hmr): Fix n-depth nested loader usage where HMR fail

Currently on npm under the `next` tag

regarding #105 