### PR TITLE
Fix HMR options being ignored (fixes #106)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,11 +140,15 @@ class ExtractCssChunks {
 
     this.hotLoaderObject = Object.assign({
       loader: hotLoader,
-      cssModules: false,
-      reloadAll: false,
+      options: {
+        cssModules: false,
+        reloadAll: false,
+      },
     }, {
-      cssModules,
-      reloadAll,
+      options: {
+        cssModules,
+        reloadAll,
+      },
     });
   }
 


### PR DESCRIPTION
`options.reloadAll` had no effect, because they were incorrectly copied into the webpack's loader.options and could never reach `hotModuleReplacement.js`. This commit fixes the copy site, allowing for options to pass through. Fixes #106
