### PR TITLE
Add a orderWarnings flag to disable warnings about CSS import order

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ module.exports = {
           // both options are optional
           filename: "[name].css",
           chunkFilename: "[id].css",
-          hot: true // optional as the plugin cannot automatically detect if you are using HOT, not for production use
+          hot: true, // optional as the plugin cannot automatically detect if you are using HOT, not for production use
+          orderWarning: true, // Disable to remove warnings about conflicting order between imports
         }
     ),
   ]

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ class CssModuleFactory {
 
 class ExtractCssChunks {
   constructor(options) {
-    this.options = Object.assign({ filename: '[name].css' }, options);
+    this.options = Object.assign({ filename: '[name].css', orderWarning: true }, options);
     const { cssModules, reloadAll } = this.options;
 
     if (!this.options.chunkFilename) {
@@ -523,16 +523,18 @@ class ExtractCssChunks {
                     // use list with fewest failed deps
                     // and emit a warning
           const fallbackModule = bestMatch.pop();
-          compilation.warnings.push(
-                        new Error(
-                            `chunk ${chunk.name || chunk.id} [mini-css-extract-plugin]\n` +
-                            'Conflicting order between:\n' +
-                            ` * ${fallbackModule.readableIdentifier(requestShortener)}\n` +
-                            `${bestMatchDeps
-                                .map(m => ` * ${m.readableIdentifier(requestShortener)}`)
-                                .join('\n')}`,
-                        ),
-                    );
+          if (this.options.orderWarning) {
+            compilation.warnings.push(
+              new Error(
+                `chunk ${chunk.name || chunk.id} [mini-css-extract-plugin]\n` +
+                'Conflicting order between:\n' +
+                ` * ${fallbackModule.readableIdentifier(requestShortener)}\n` +
+                `${bestMatchDeps
+                  .map(m => ` * ${m.readableIdentifier(requestShortener)}`)
+                  .join('\n')}`,
+              ),
+            );
+          }
           usedModules.add(fallbackModule);
         }
       }


### PR DESCRIPTION
Add an option to disable warnings relating to consistent CSS import order as seen in https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250, as there does not seem to be a clear way to find and fix the source of the warnings.