### PR TITLE
fix(index.js): Support function loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ module.exports = {
           // both options are optional
           filename: "[name].css",
           chunkFilename: "[id].css",
-          hot: true, // if you want HMR - we try to automatically inject hot reloading but if it's not working, add it to the config
+          hot: true, // optional as the plugin cannot automatically detect if you are using HOT, not for production use
           orderWarning: true, // Disable to remove warnings about conflicting order between imports
           reloadAll: true, // when desperation kicks in - this is a brute force HMR flag
           cssModules: true // if you use cssModules, this can help.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ module.exports = {
           // both options are optional
           filename: "[name].css",
           chunkFilename: "[id].css",
-          hot: true, // optional as the plugin cannot automatically detect if you are using HOT, not for production use
+          hot: true, // if you want HMR - we try to automatically inject hot reloading but if it's not working, add it to the config
           orderWarning: true, // Disable to remove warnings about conflicting order between imports
           reloadAll: true, // when desperation kicks in - this is a brute force HMR flag
           cssModules: true // if you use cssModules, this can help.

--- a/src/index.js
+++ b/src/index.js
@@ -426,6 +426,9 @@ class ExtractCssChunks {
       this.traverseDepthFirst(rule, (node) => {
         if (node && node.use && Array.isArray(node.use)) {
           const isMiniCss = node.use.some((l) => {
+            if (typeof l === 'function') {
+              return false;
+            }
             const needle = l.loader || l;
             return needle.includes(pluginName);
           });

--- a/test/cases/function-loader/expected/main.css
+++ b/test/cases/function-loader/expected/main.css
@@ -1,0 +1,2 @@
+body { background: red; }
+

--- a/test/cases/function-loader/index.js
+++ b/test/cases/function-loader/index.js
@@ -1,0 +1,1 @@
+import './style.css';

--- a/test/cases/function-loader/style.css
+++ b/test/cases/function-loader/style.css
@@ -1,0 +1,1 @@
+body { background: red; }

--- a/test/cases/function-loader/webpack.config.js
+++ b/test/cases/function-loader/webpack.config.js
@@ -1,0 +1,21 @@
+const Self = require('../../../');
+
+module.exports = {
+  entry: './index.js',
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          () => ({ loader: 'css-loader' }),
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new Self({
+      filename: '[name].css',
+      hot: true,
+    }),
+  ],
+};


### PR DESCRIPTION
updateWebpackConfig previously expected `use` entries to be strings or arrays, and would throw `needle.includes is not a function` errors when given a function that returns a loader object.

I ran into this while using react-svg-loader:

```js
{
  test: /\.svg$/,
  use: [
    ({resource}) => {
      const prefix = `svg${stringHash(
        path.relative(webDir, resource)
      )}`
      return {
        loader: 'react-svg-loader',
        options: {
          svgo: {
            plugins: [
              {
                cleanupIDs: {
                  prefix
                }
              }
            ]
          }
        }
      }
    }
  ]
}
```

It uses a function to return a loader object per resource, so that svgo can be instructed to give svgs unique ids.