### PR TITLE
fix:Compile HMR separately to be compatible with IE11 (#118)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "scripts": {
     "start": "npm run build -- -w",
-    "build": "cross-env NODE_ENV=production babel src -d dist --ignore 'src/**/*.test.js' --copy-files",
+    "build": "cross-env NODE_ENV=production babel src -d dist --ignore 'src/**/*.test.js' --ignore 'src/hotModuleReplacement.js' --copy-files && cross-env NODE_ENV=production babel --no-babelrc src/hotModuleReplacement.js --out-file dist/hotModuleReplacement.js --presets=env",
     "clean": "del-cli dist",
     "lint": "eslint --cache --fix src",
     "prebuild": "npm run clean",


### PR DESCRIPTION
In the project, because it is compatible with IE11, but it can't be used normally in development mode, it is found that hmr contains es6 code.
