### PR TITLE
add browsers to babelrc's target

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,8 @@
 			{
 				"useBuiltIns": true,
 				"targets": {
-					"node": "6.11.5"
+					"node": "6.11.5",
+					"browsers": "cover 99.5%"
 				},
 				"exclude": [
 					"transform-async-to-generator",


### PR DESCRIPTION
Cause `hotModuleReplacement.js` will be used in browsers, it needs to be compiled for low version browsers