### PR TITLE
fix:Improved path Settings for hotloader.js load hmr.js (#118)

### DIFF
--- a/src/hotLoader.js
+++ b/src/hotLoader.js
@@ -18,7 +18,7 @@ module.exports = function (content) {
   return content + `
     if(module.hot) {
       // ${Date.now()}
-      var cssReload = require(${loaderUtils.stringifyRequest(this, '!' + path.join(__dirname, 'hotModuleReplacement.js'))})(module.id, ${JSON.stringify(options)});
+      var cssReload = require(${loaderUtils.stringifyRequest(this, path.join(__dirname, 'hotModuleReplacement.js'))})(module.id, ${JSON.stringify(options)});
       module.hot.dispose(cssReload);
       ${accept};
     }


### PR DESCRIPTION
Remove the exclamation point so that HMR can be handled by other loader.
e.g: babel-loader.