### PR TITLE
Add linkAttributes option that enables custom attributes to be added to the DOM element

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ module.exports = {
           orderWarning: true, // Disable to remove warnings about conflicting order between imports
           reloadAll: true, // when desperation kicks in - this is a brute force HMR flag
           cssModules: true // if you use cssModules, this can help.
+          linkAttributes: { // allows to add custom attributes to the DOM element
+            "data-source": "extract-css-chunks",
+          },
         }
     ),
   ]

--- a/src/index.js
+++ b/src/index.js
@@ -380,6 +380,7 @@ class ExtractCssChunks {
                           'var linkTag = document.createElement("link");',
                           'linkTag.rel = "stylesheet";',
                           'linkTag.type = "text/css";',
+                          ...this.linkAttributeTemplate(),
                           'linkTag.onload = resolve;',
                           'linkTag.onerror = function(event) {',
                           Template.indent([
@@ -404,6 +405,14 @@ class ExtractCssChunks {
                 },
             );
     });
+  }
+
+  linkAttributeTemplate() {
+    const attrs = this.options.linkAttributes;
+    if (!attrs) {
+      return [];
+    }
+    return Object.keys(attrs).map(key => `linkTag.setAttribute(${JSON.stringify(key)}, ${JSON.stringify(attrs[key])});`);
   }
 
   traverseDepthFirst(root, visit) {


### PR DESCRIPTION
In our project we need the ability to detect which link tags are injected automatically by webpack and which are created some other way.

For comparison, `style-loader` has `attrs` option for this same purpose.