### PR TITLE
fix: broken hot reloading of global styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-css-chunks-webpack-plugin",
-  "version": "4.0.0-beta.2",
+  "version": "0.0.0-development",
   "description": "Extract CSS from chunks into stylesheets + HMR. Supports Webpack 4 + SSR",
   "license": "MIT",
   "author": "James Gillmore <james@faceyspacey.com>",

--- a/src/loader.js
+++ b/src/loader.js
@@ -150,12 +150,13 @@ export function pitch(request) {
       return callback(e);
     }
     let resultSource = `// extracted by ${pluginName}`;
-    if (locals && typeof resultSource !== 'undefined') {
-      const result = `\nmodule.exports = ${JSON.stringify(locals)};`;
-      resultSource += query.hot
-        ? hotLoader(result, { context: this.context, query })
-        : '';
-    }
+    const result = locals
+      ? `\nmodule.exports = ${JSON.stringify(locals)};`
+      : '';
+
+    resultSource += query.hot
+      ? hotLoader(result, { context: this.context, query })
+      : '';
 
     return callback(null, resultSource);
   });

--- a/test/cases/hmr/expected/main.js
+++ b/test/cases/hmr/expected/main.js
@@ -88,7 +88,7 @@
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// extracted by mini-css-extract-plugin
+// extracted by extract-css-chunks-webpack-plugin
 
 /***/ })
 /******/ ]);


### PR DESCRIPTION
if local scoped hash maps were not returned, the loader was not adding HMR to the file at all.
