### PR TITLE
feat: add orderWarnings flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,7 @@ class ExtractCssChunksPlugin {
     this.options = Object.assign(
       {
         filename: '[name].css',
+        orderWarning: true,
       },
       options
     );
@@ -495,18 +496,22 @@ class ExtractCssChunksPlugin {
           // use list with fewest failed deps
           // and emit a warning
           const fallbackModule = bestMatch.pop();
-          compilation.warnings.push(
-            new Error(
-              `chunk ${chunk.name ||
-                chunk.id} [extract-css-chunks-webpack-plugin]\n` +
-                'Conflicting order between:\n' +
-                ` * ${fallbackModule.readableIdentifier(requestShortener)}\n` +
-                `${bestMatchDeps
-                  .map((m) => ` * ${m.readableIdentifier(requestShortener)}`)
-                  .join('\n')}`
-            )
-          );
-          usedModules.add(fallbackModule);
+          if (this.options.orderWarning) {
+            compilation.warnings.push(
+              new Error(
+                `chunk ${chunk.name ||
+                  chunk.id} [extract-css-chunks-webpack-plugin]\n` +
+                  'Conflicting order between:\n' +
+                  ` * ${fallbackModule.readableIdentifier(
+                    requestShortener
+                  )}\n` +
+                  `${bestMatchDeps
+                    .map((m) => ` * ${m.readableIdentifier(requestShortener)}`)
+                    .join('\n')}`
+              )
+            );
+            usedModules.add(fallbackModule);
+          }
         }
       }
     } else {


### PR DESCRIPTION
The flag defaults to true, which retains the existing behaviour of
warnings when there is conflicting import order between multiple CSS
files. When set to false, these warnings are not generated.

Note that there is no new documentation because the `orderWarnings` flag is already documented in the README