### PR TITLE
Switch appendChild to replaceBefore in hmr script

### DIFF
--- a/src/hmr/hotModuleReplacement.js
+++ b/src/hmr/hotModuleReplacement.js
@@ -116,7 +116,7 @@ function updateCss(el, url) {
 
   newEl.href = `${url}?${Date.now()}`;
 
-  el.parentNode.appendChild(newEl);
+  el.parentNode.insertBefore(newEl, el);
 }
 
 function getReloadUrl(href, src) {


### PR DESCRIPTION
This change is to keep the link tags on the same place in the dom as there where from the beginning. This is to keep the order of css assets. 
e.g. if you have a inline style tag last in your document that overwrite css from linked stylesheets, after HMR have compiled and inserted new links to the stylesheets, the the inline styles are still last and the import order for the css rules are still correct 