### PR TITLE
fix: restore `insert` option functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -379,7 +379,7 @@ class ExtractCssChunksPlugin {
                       ])
                     : '',
                   insert
-                    ? 'insert(linkTag);'
+                    ? `var insert = ${insert};\ninsert(linkTag);`
                     : 'var head = document.getElementsByTagName("head")[0]; head.appendChild(linkTag)',
                 ]),
                 '}).then(function() {',


### PR DESCRIPTION
fixes faceyspacey/extract-css-chunks-webpack-plugin#264