### PR TITLE
fix: ExtractCssChunksPlugin.loader is a string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 declare module 'extract-css-chunks-webpack-plugin' {
-  import { ChunkData, Loader, Plugin } from 'webpack';
+  import { ChunkData, Plugin } from 'webpack';
 
   class ExtractCssChunksPlugin extends Plugin {
-    static loader: Loader;
+    static loader: string;
 
     constructor(options?: ExtractCssChunksPlugin.PluginOptions);
   }


### PR DESCRIPTION
Because else it doesn't work with:
```
{
          loader: CssExtractPlugin.loader,
          options: { hmr: !production && target !== 'node' },
        }
```

type Loader is `string | NewLoader` and `NewLoader` is:

```
interface NewLoader {
        loader: string;
        options?: { [name: string]: any };
    }
```