### PR TITLE
fix: Check if bestMatch exists before pop()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -498,6 +498,7 @@ class ExtractCssChunksPlugin {
           // no module found => there is a conflict
           // use list with fewest failed deps
           // and emit a warning
+          if (!bestMatch) break;
           const fallbackModule = bestMatch.pop();
 
           if (!this.options.ignoreOrder) {


### PR DESCRIPTION
I'm using nuxt.js which use extract-css-chunks-webpack-plugin under the hood, I ran into an error where it says:

`ERROR in chunk 159
159.9676669.css
Cannot read property 'pop' of undefined`

I just added validation before pop(). 
