### PR TITLE
Do not add style as body link if it already exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -330,6 +330,7 @@ class ExtractCssChunksPlugin {
               '',
               `// ${pluginName} CSS loading`,
               `var supportsPreload = ${supportsPreload}`,
+              `var linkExists = false`,
               `var cssChunks = ${JSON.stringify(chunkMap)};`,
               'if(installedCssChunks[chunkId]) promises.push(installedCssChunks[chunkId]);',
               'else if(installedCssChunks[chunkId] !== 0 && cssChunks[chunkId]) {',
@@ -343,7 +344,13 @@ class ExtractCssChunksPlugin {
                   Template.indent([
                     'var tag = existingLinkTags[i];',
                     'var dataHref = tag.getAttribute("data-href") || tag.getAttribute("href");',
-                    'if((tag.rel === "stylesheet" || tag.rel === "preload") && (dataHref === href || dataHref === fullhref)) return resolve();',                  ]),
+                    'if((tag.rel === "stylesheet" || tag.rel === "preload") && (dataHref === href || dataHref === fullhref)) {',
+                    Template.indent([
+                      'linkExists = true',
+                      'return resolve();',
+                    ]),
+                    '}',
+                  ]),
                   '}',
                   'var existingStyleTags = document.getElementsByTagName("style");',
                   'for(var i = 0; i < existingStyleTags.length; i++) {',
@@ -387,7 +394,7 @@ class ExtractCssChunksPlugin {
                 '}).then(function() {',
                 Template.indent([
                   'installedCssChunks[chunkId] = 0;',
-                  'if(supportsPreload) {',
+                  'if(!linkExists && supportsPreload) {',
                   Template.indent([
                     'var execLinkTag = document.createElement("link");',
                     `execLinkTag.href =  ${mainTemplate.requireFn}.p + ${linkHrefPath};`,


### PR DESCRIPTION
When a stylesheet link already exists in the head and preload is supported the stylesheet is added twice.

This is also mentioned in https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/pull/300#issuecomment-752047229

This PR  prevent the link from being added to the body if it already is loaded.