### PR TITLE
Fix errors when accessing document global on server

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -330,6 +330,7 @@ class ExtractCssChunksPlugin {
               '',
               `// ${pluginName} CSS loading`,
               `var supportsPreload = ${supportsPreload}`,
+              `if (typeof document === "undefined") { return; }`,
               `var cssChunks = ${JSON.stringify(chunkMap)};`,
               'if(installedCssChunks[chunkId]) promises.push(installedCssChunks[chunkId]);',
               'else if(installedCssChunks[chunkId] !== 0 && cssChunks[chunkId]) {',

--- a/test/cases/insert-function/expected/main.js
+++ b/test/cases/insert-function/expected/main.js
@@ -83,6 +83,7 @@
 /******/
 /******/ 		// extract-css-chunks-webpack-plugin CSS loading
 /******/ 		var supportsPreload = (function() { try { return document.createElement("link").relList.supports("preload"); } catch(e) { return false; }}());
+/******/ 		if (typeof document === "undefined") { return; }
 /******/ 		var cssChunks = {"1":1};
 /******/ 		if(installedCssChunks[chunkId]) promises.push(installedCssChunks[chunkId]);
 /******/ 		else if(installedCssChunks[chunkId] !== 0 && cssChunks[chunkId]) {

--- a/test/cases/insert-function/webpack.config.e2e.js
+++ b/test/cases/insert-function/webpack.config.e2e.js
@@ -1,3 +1,4 @@
+/* eslint-env browser */
 const path = require('path');
 
 const Self = require('../../../');
@@ -65,7 +66,7 @@ module.exports = {
       filename: '[name].css',
       chunkFilename: '[id].css',
       insert: (linkTag) => {
-        document.head.appendChild(linkTag)
+        document.head.appendChild(linkTag);
       },
     }),
   ],

--- a/test/cases/insert-string/expected/main.js
+++ b/test/cases/insert-string/expected/main.js
@@ -83,6 +83,7 @@
 /******/
 /******/ 		// extract-css-chunks-webpack-plugin CSS loading
 /******/ 		var supportsPreload = (function() { try { return document.createElement("link").relList.supports("preload"); } catch(e) { return false; }}());
+/******/ 		if (typeof document === "undefined") { return; }
 /******/ 		var cssChunks = {"1":1};
 /******/ 		if(installedCssChunks[chunkId]) promises.push(installedCssChunks[chunkId]);
 /******/ 		else if(installedCssChunks[chunkId] !== 0 && cssChunks[chunkId]) {


### PR DESCRIPTION
When using the plugin in a server-side rendering context there is no document global where script or link tags could be added to. In this case typically all scripts and link tags are collected and added by the renderer itself so nothing needs to be executed by the plugin on require.

This patch detects the existence of the document global and skips adding nodes if it doesn't exist. Also fixed test cases. Feedback welcome, maybe there is a better way to do this?